### PR TITLE
fix: remoção pois o retorno é uma string e n pode ser convertida em json

### DIFF
--- a/AdaTech.AIntelligence.WebAPI/wwwroot/templates/home/js/logoutJs.js
+++ b/AdaTech.AIntelligence.WebAPI/wwwroot/templates/home/js/logoutJs.js
@@ -7,7 +7,6 @@
             const response = await fetch('https://localhost:7016/api/userauth/logout', { 
                 method: 'POST'
             });
-            const responseData = await response.json();
             alert("Você será redirecionado para a página de login!"); 
             window.location.href = '/templates/authentication/login.html'; 
         } catch (error) {


### PR DESCRIPTION
A primeira chamada estava correta e deslogava o usuário com sucesso mas a linha:

`const responseData = await response.json();`

estava fazendo com que caísse no catch do JS pois não conseguia fazer a conversão de uma string em um Json.

Este objeto já não estava sendo utilizado na a resposta, logo, foi retirado resolvendo o erro de duplicação.